### PR TITLE
Fixing ERROR 'Operation not permitted'

### DIFF
--- a/songrec-rename.sh
+++ b/songrec-rename.sh
@@ -68,12 +68,12 @@ for t in *; do
     else
         echo "$t is unrecognized by Shazam."
     fi
-	
+
+	rm srr.tmp &&
     year=""
     album=""
     title=""
     subtitle=""
-    rm srr.tmp
 done
 }
 

--- a/songrec-rename.sh
+++ b/songrec-rename.sh
@@ -68,8 +68,11 @@ for t in *; do
     else
         echo "$t is unrecognized by Shazam."
     fi
-
-	rm srr.tmp &&
+    rm srr.tmp
+    while [ -f srr.tmp ];
+    do
+        sleep 1
+    done	
     year=""
     album=""
     title=""

--- a/songrec-rename.sh
+++ b/songrec-rename.sh
@@ -68,11 +68,14 @@ for t in *; do
     else
         echo "$t is unrecognized by Shazam."
     fi
+
     rm srr.tmp
     while [ -f srr.tmp ];
     do
         sleep 1
-    done	
+    done
+    sleep 1
+    
     year=""
     album=""
     title=""


### PR DESCRIPTION
this change fixes the following error that I got multiple times while using this script 

ERROR: `/usr/local/bin/songrec-rename: line 45: srr.tmp: Operation not permitted`

It was trying to write the content of the next file into the same object, because `rm srr.tmp` was not done yet.